### PR TITLE
Added new pattern for out_of_zone status

### DIFF
--- a/lib/whois/record/parser/whois.nic.cz.rb
+++ b/lib/whois/record/parser/whois.nic.cz.rb
@@ -61,6 +61,8 @@ module Whois
                 :expired
               when "domain is not generated into zone"
                 :out_of_zone
+              when "the domain isn't generated in the zone"
+                :out_of_zone
               when "to be deleted"
                 :delete_candidate
               else


### PR DESCRIPTION
Opraven problém s Unknown status `The domain isn't generated in the zone'. Ozkoušeno na lokále, že doménu v takovém stavu označí jako :out_of_zone.
